### PR TITLE
Item spawning after defeating enemies

### DIFF
--- a/Assets/Prefabs/GameResources/Resources/GameResources.prefab
+++ b/Assets/Prefabs/GameResources/Resources/GameResources.prefab
@@ -55,7 +55,8 @@ MonoBehaviour:
   pricePrefab: {fileID: 3381491085019717092, guid: 1d7003f3366004f83a1be9272fc528da, type: 3}
   pillSO: {fileID: 11400000, guid: f11f146ca08ab9a47ad3fdf3d246414c, type: 2}
   healthPotionSO: {fileID: 11400000, guid: 0642899e386ab9544905951b66823fe0, type: 2}
-  scalpelSO: {fileID: 0}
+  currencySO: {fileID: 11400000, guid: 876f532a05269894793f3107c9a98459, type: 2}
   healthPotionIcon: {fileID: 1472682641, guid: a720362be5df15140958337462fac675, type: 3}
   weaponIcon: {fileID: 1203317424, guid: c2d05ccd526638c4c86fde28754a41d4, type: 3}
   pillIcon: {fileID: -1213312351, guid: a720362be5df15140958337462fac675, type: 3}
+  currencyIcon: {fileID: 21300000, guid: 2e3dae901f8502e45b76586dfc95aeb0, type: 3}

--- a/Assets/Prefabs/InventoryItems/ConsumableItem.prefab
+++ b/Assets/Prefabs/InventoryItems/ConsumableItem.prefab
@@ -165,7 +165,7 @@ SpriteRenderer:
   m_SortingLayerID: -1024326055
   m_SortingLayer: 4
   m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 3b0d46ab34f799e48a8c4f3c495480cf, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 2e3dae901f8502e45b76586dfc95aeb0, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -201,7 +201,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2375222679657170150, guid: 1d7003f3366004f83a1be9272fc528da, type: 3}
       propertyPath: m_Text
-      value: 12
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2618452205596595987, guid: 1d7003f3366004f83a1be9272fc528da, type: 3}
       propertyPath: m_Enabled

--- a/Assets/Scenes/MainGameScene.unity
+++ b/Assets/Scenes/MainGameScene.unity
@@ -5425,6 +5425,18 @@ PrefabInstance:
       propertyPath: itemsForSale.Array.data[5]
       value: 
       objectReference: {fileID: 1856120119}
+    - target: {fileID: 2193794874400841173, guid: 133ebcadfa31b7f43af7f6b8b97ab9f7, type: 3}
+      propertyPath: spawnableConsumableItems.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2193794874400841173, guid: 133ebcadfa31b7f43af7f6b8b97ab9f7, type: 3}
+      propertyPath: spawnableConsumableItems.Array.data[0]
+      value: 
+      objectReference: {fileID: 2360887131288210285, guid: c41c5ee056fbcef40b619d22d61c6144, type: 3}
+    - target: {fileID: 2193794874400841173, guid: 133ebcadfa31b7f43af7f6b8b97ab9f7, type: 3}
+      propertyPath: spawnableConsumableItems.Array.data[1]
+      value: 
+      objectReference: {fileID: 996181946665298737, guid: d3bd97a1781acdf46b61f188eab889ef, type: 3}
     - target: {fileID: 2336627268966236151, guid: 133ebcadfa31b7f43af7f6b8b97ab9f7, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0

--- a/Assets/Scriptable Objects/Inventory System/ConsumableItem.cs
+++ b/Assets/Scriptable Objects/Inventory System/ConsumableItem.cs
@@ -16,6 +16,7 @@ public class ConsumableItem : InventoryItem
     [Space(5)]
     [Tooltip("How many hearts(1) or half hearts(0.5) the item restores. Value is 0 if ability doesn't exist")]
     public float healthRestore;
+    public int currencyIncrease;
 
     [Header("Permanent Power Upgrade Attributes (PERK)")] [Space(5)]
     public float attackStrengthUpgrade;

--- a/Assets/Scripts/GameManager/GameManager.cs
+++ b/Assets/Scripts/GameManager/GameManager.cs
@@ -523,7 +523,7 @@ public class GameManager : SingletonMonoBehavior<GameManager>
         itemController.sprite = consumableItemController.sprite;
         lootItemGameObject.AddComponent<CircleCollider2D>();
 
-        lootItem.Initialize(GameResources.Instance.currencyIcon, spawnPosition, Color.yellow);
+        lootItem.Initialize(itemController.item.itemSprite, spawnPosition, Color.yellow);
     }
 
     public void QuitGame()

--- a/Assets/Scripts/GameManager/GameManager.cs
+++ b/Assets/Scripts/GameManager/GameManager.cs
@@ -505,6 +505,27 @@ public class GameManager : SingletonMonoBehavior<GameManager>
         player = currentPlayer;
     }
 
+    /// <summary>
+    /// Spawn an item
+    /// </summary>
+    public void SpawnItem(Vector3 spawnPosition) {
+        // Instantiate the item
+        ConsumableItemController consumableItemController = GameResources.Instance.consumablePrefab.GetComponent<ConsumableItemController>();
+        GameObject lootItemGameObject = Instantiate(GameResources.Instance.chestItemPrefab, spawnPosition, Quaternion.identity);
+        lootItemGameObject.tag = "interactableObject";
+        ChestItem lootItem = lootItemGameObject.GetComponent<ChestItem>();
+
+        // Instantiate teeth
+        ConsumableItemController itemController = lootItemGameObject.AddComponent<ConsumableItemController>();
+        itemController.priceView = consumableItemController.priceView;
+        itemController.priceText = consumableItemController.priceText;
+        itemController.item = GameResources.Instance.currencySO;
+        itemController.sprite = consumableItemController.sprite;
+        lootItemGameObject.AddComponent<CircleCollider2D>();
+
+        lootItem.Initialize(GameResources.Instance.currencyIcon, spawnPosition, Color.yellow);
+    }
+
     public void QuitGame()
     {
         SceneManager.LoadScene("Home");

--- a/Assets/Scripts/GameManager/GameResources.cs
+++ b/Assets/Scripts/GameManager/GameResources.cs
@@ -101,9 +101,9 @@ public class GameResources : MonoBehaviour
     public ConsumableItem healthPotionSO;
 
     #region Tooltip
-    [Tooltip("Scalpel")]
+    [Tooltip("Currency")]
     #endregion
-    public ConsumableItem scalpelSO;
+    public ConsumableItem currencySO;
     
     #region Tooltip
     [Tooltip("Populate with health potion sprite")]
@@ -122,4 +122,10 @@ public class GameResources : MonoBehaviour
     #endregion
     // This resource is for chest item sprite - pill
     public Sprite pillIcon;
+
+    #region Tooltip
+    [Tooltip("Populate with currency sprite")]
+    #endregion
+    // This resource is for chest item sprite - currency
+    public Sprite currencyIcon;
 }

--- a/Assets/Scripts/Health + Damage/EnemyHealth.cs
+++ b/Assets/Scripts/Health + Damage/EnemyHealth.cs
@@ -6,11 +6,13 @@ public class EnemyHealth : MonoBehaviour
 {
     [SerializeField] private EnemyController enemyController;
     public float currentHealthPoints;
+    private ConsumableItemController consumableItemController;
 
     void Awake()
     {
         enemyController = GetComponent<EnemyController>();
         currentHealthPoints = enemyController.GetHealthPoints();
+        consumableItemController = GameResources.Instance.consumablePrefab.GetComponent<ConsumableItemController>();
     }
 
     public void ChangeHealth(float healthChange)
@@ -19,7 +21,36 @@ public class EnemyHealth : MonoBehaviour
 
         if (currentHealthPoints <= 0)
         {
+            Transform childTransform = transform.Find("Body");
+            Vector3 enemyPosition = childTransform.position;
             Destroy(gameObject);
+            GameManager.Instance.SpawnItem(enemyPosition);
+            // // Instantiate the item
+            // GameObject lootItemGameObject = Instantiate(GameResources.Instance.chestItemPrefab, enemyPosition, Quaternion.identity);
+            // lootItemGameObject.tag = "interactableObject";
+            // ChestItem lootItem = lootItemGameObject.GetComponent<ChestItem>();
+            // Debug.Log(childTransform);
+            // Debug.Log(enemyPosition);
+            // // Instantiate the health potion
+            // ConsumableItemController itemController = lootItemGameObject.AddComponent<ConsumableItemController>();
+            // itemController.priceView = consumableItemController.priceView;
+            // itemController.priceText = consumableItemController.priceText;
+            // itemController.item = GameResources.Instance.healthPotionSO;
+            // itemController.sprite = consumableItemController.sprite;
+            // lootItemGameObject.AddComponent<CircleCollider2D>();
+
+            // Debug.Log("hello3");
+            // lootItem.Initialize(GameResources.Instance.healthPotionIcon, enemyPosition, Color.yellow);
         }
+    }
+
+    /// <summary>
+    /// Materialize the chest item
+    /// </summary>
+    private IEnumerator MaterializeItem(Color materializeColor, SpriteRenderer spriteRenderer, MaterializeEffect materializeEffect)
+    {
+        SpriteRenderer[] spriteRendererArray = new SpriteRenderer[] { spriteRenderer };
+        Debug.Log("hello4");
+        yield return StartCoroutine(materializeEffect.MaterializeRoutine(GameResources.Instance.materializeShader, materializeColor, 1f, spriteRendererArray, GameResources.Instance.litMaterial));
     }
 }

--- a/Assets/Scripts/Health + Damage/EnemyHealth.cs
+++ b/Assets/Scripts/Health + Damage/EnemyHealth.cs
@@ -6,13 +6,11 @@ public class EnemyHealth : MonoBehaviour
 {
     [SerializeField] private EnemyController enemyController;
     public float currentHealthPoints;
-    private ConsumableItemController consumableItemController;
 
     void Awake()
     {
         enemyController = GetComponent<EnemyController>();
         currentHealthPoints = enemyController.GetHealthPoints();
-        consumableItemController = GameResources.Instance.consumablePrefab.GetComponent<ConsumableItemController>();
     }
 
     public void ChangeHealth(float healthChange)
@@ -25,32 +23,6 @@ public class EnemyHealth : MonoBehaviour
             Vector3 enemyPosition = childTransform.position;
             Destroy(gameObject);
             GameManager.Instance.SpawnItem(enemyPosition);
-            // // Instantiate the item
-            // GameObject lootItemGameObject = Instantiate(GameResources.Instance.chestItemPrefab, enemyPosition, Quaternion.identity);
-            // lootItemGameObject.tag = "interactableObject";
-            // ChestItem lootItem = lootItemGameObject.GetComponent<ChestItem>();
-            // Debug.Log(childTransform);
-            // Debug.Log(enemyPosition);
-            // // Instantiate the health potion
-            // ConsumableItemController itemController = lootItemGameObject.AddComponent<ConsumableItemController>();
-            // itemController.priceView = consumableItemController.priceView;
-            // itemController.priceText = consumableItemController.priceText;
-            // itemController.item = GameResources.Instance.healthPotionSO;
-            // itemController.sprite = consumableItemController.sprite;
-            // lootItemGameObject.AddComponent<CircleCollider2D>();
-
-            // Debug.Log("hello3");
-            // lootItem.Initialize(GameResources.Instance.healthPotionIcon, enemyPosition, Color.yellow);
         }
-    }
-
-    /// <summary>
-    /// Materialize the chest item
-    /// </summary>
-    private IEnumerator MaterializeItem(Color materializeColor, SpriteRenderer spriteRenderer, MaterializeEffect materializeEffect)
-    {
-        SpriteRenderer[] spriteRendererArray = new SpriteRenderer[] { spriteRenderer };
-        Debug.Log("hello4");
-        yield return StartCoroutine(materializeEffect.MaterializeRoutine(GameResources.Instance.materializeShader, materializeColor, 1f, spriteRendererArray, GameResources.Instance.litMaterial));
     }
 }

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -336,6 +336,10 @@ public class PlayerController : MonoBehaviour
         {
             upgradeScreen.SetActive(true);
         }
+        else if (consumable.item.itemName == "Teeth") 
+        {
+            player.CurrentCurrency += consumable.item.currencyIncrease;
+        }
         else
         {
             InventoryItem dropItem = playerInventory.GetItemAt(2);


### PR DESCRIPTION
### Features
- Item materializes after defeating enemies (currently have it only set to teeth currency spawning in place since chests and shops will contain the other consumable items pills and health potion)
- I've set it to increase by `5` after every pickup (configurable in Currency SO)
- I've removed teeth from shop as a sellable item since it's a currency item

### Testing
- Defeat any enemy and teeth should spawn in its place
- When picking up the teeth, it should increase the player's currency amount in the UI

### Demo

https://github.com/josephlatina/DungeonCrawler/assets/74115441/869c2a3f-3ed4-4b02-bc5b-106b816142d8

