### PR TITLE
Extend Melee Reach + Increase InteractTrigger

### DIFF
--- a/Assets/Animation/Player/PlayerMeleeAttack.anim
+++ b/Assets/Animation/Player/PlayerMeleeAttack.anim
@@ -72,18 +72,27 @@ AnimationClip:
         outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
       - serializedVersion: 3
         time: 0.16666667
-        value: {x: 0.8, y: 1, z: 0}
-        inSlope: {x: 0, y: 0, z: 0}
-        outSlope: {x: 0, y: 0, z: 0}
+        value: {x: 1, y: 1.5, z: 0}
+        inSlope: {x: 3.9999998, y: 0, z: 0}
+        outSlope: {x: 3.9999998, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 0.2
+        value: {x: 2, y: 0.444, z: 0}
+        inSlope: {x: 0, y: -51.840004, z: 0}
+        outSlope: {x: 0, y: -51.840004, z: 0}
         tangentMode: 0
         weightedMode: 0
         inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
         outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
       - serializedVersion: 3
         time: 0.25
-        value: {x: 0.8, y: -1, z: 0}
-        inSlope: {x: 0, y: 0, z: 0}
-        outSlope: {x: 0, y: 0, z: 0}
+        value: {x: 1, y: -1.5, z: 0}
+        inSlope: {x: -3.692309, y: 0, z: 0}
+        outSlope: {x: -3.692309, y: 0, z: 0}
         tangentMode: 0
         weightedMode: 0
         inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
@@ -320,7 +329,16 @@ AnimationClip:
         outWeight: 0.33333334
       - serializedVersion: 3
         time: 0.16666667
-        value: 0.8
+        value: 1
+        inSlope: 3.9999998
+        outSlope: 3.9999998
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.2
+        value: 2
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -329,9 +347,9 @@ AnimationClip:
         outWeight: 0.33333334
       - serializedVersion: 3
         time: 0.25
-        value: 0.8
-        inSlope: 0
-        outSlope: 0
+        value: 1
+        inSlope: -3.692309
+        outSlope: -3.692309
         tangentMode: 136
         weightedMode: 0
         inWeight: 0.33333334
@@ -366,7 +384,7 @@ AnimationClip:
         outWeight: 0.33333334
       - serializedVersion: 3
         time: 0.16666667
-        value: 1
+        value: 1.5
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -375,7 +393,7 @@ AnimationClip:
         outWeight: 0.33333334
       - serializedVersion: 3
         time: 0.25
-        value: -1
+        value: -1.5
         inSlope: 0
         outSlope: 0
         tangentMode: 136

--- a/Assets/Prefabs/Player/Player.prefab
+++ b/Assets/Prefabs/Player/Player.prefab
@@ -259,7 +259,7 @@ CircleCollider2D:
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
   serializedVersion: 2
-  m_Radius: 1.25
+  m_Radius: 1.8
 --- !u!1 &6963947361320136118
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
- Slightly altered the player's melee attack so that the weapon reaches out a bit further when swinging
- Increased the size of the InteractTrigger on the player to better account for the size of the new sprite